### PR TITLE
[cake] Fix vdsl2 overhead description

### DIFF
--- a/content/codel/wiki/Cake.md
+++ b/content/codel/wiki/Cake.md
@@ -137,10 +137,7 @@ and is thus a little more compact than if it did.
 
 Two more new keywords deal with the basic VDSL2 configurations. Again,
 the overheads use IP as a baseline, but this time ATM cell-framing is
-turned off. Apparently PTM does have a small additional overhead on the
-order of 1/128, due to HDLC framing which attaches special meaning to
-0x7D and 0x7E bytes; I might need to add approximate handling for that,
-kernel-side.
+turned off.
 
 pppoe-ptm (27)\
 bridged-ptm (19)


### PR DESCRIPTION
The old text:
Apparently PTM does have a small additional overhead on the
order of 1/128, due to HDLC framing which attaches special meaning to
0x7D and 0x7E bytes; I might need to add approximate handling for that,
kernel-side.
was slightly inaccurate, in that VDSL2 does noy use HDLC on the user visible
data bearer, but a deterministic 64/65 encoding. And since no HDLC in
byte stuffing mode is used the kernel needs not to learn something new.
For VDSL1 HDLC actually is used, but there the PTM overhead is 5-6 Byte
compared to VDSL2's 4 Byte, so cake's keywords will not work with VDSL1
anyway.

For reference:
VDSL1 (nach G.993.1 Annex H): 1B Opening Flag Sequence (OFS), 1B Address Field (AF), 1B Control Field (CF), 2B TC-CRC (PTM-FCS), 1B Closing Flag Sequence (CFS not used with back-2-back PTM frames)

VDSL2 (IEEE 802.3-2012 61.3): 1B Start of Frame (S), 1B End of Frame (Ck), 2B TC-CRC (PTM-FCS)

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>