### PR TITLE
Add link to mailing lists to the menu.html so it's visible on all pages

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -20,6 +20,7 @@
           <h4>Find us elsewhere</h4>
         </div>
         <div class="panel-body">
+          <a href="https://lists.bufferbloat.net/listinfo/">Bufferbloat Mailing Lists</a><br />
           <a href="https://www.twitter.com/#bufferbloat">#bufferbloat</a>  on Twitter<br />
           <a href="https://plus.google.com/u/0/explore/bufferbloat">Google+</a> group<br />
           <a href="http://richb-hanover.github.io/bufferbloat-site">Archived Bufferbloat pages</a> from the Wayback Machine<br />


### PR DESCRIPTION
The Bloat, Codel, MakeWifiFast, Cerowrt-development lists are an incredibly active source of info about our progress. Each page should have a prominent link to those lists