### PR TITLE
Update Linux Tips for fq_codel and ECN

### DIFF
--- a/content/bloat/wiki/Linux_Tips.md
+++ b/content/bloat/wiki/Linux_Tips.md
@@ -97,22 +97,27 @@ drivers and hardware is why this is going to be an interesting problem
 Loaded guns can hurt if you aim them at your foot and pull the trigger.
 So please do be careful, and think...
 
-Enable <link>ECN</link>, <link>SACK</link>, and <link>DSACK</link>
-------------------------------------------------------------------
+Enable FQ_CODEL, ECN, SACK, and DSACK
+-------------------------------------
 
 These sysctl settings can be stored in the main /etc/sysctl.conf file,
 or in a file in the /etc/sysctl.d directory.
 
-
 ```
+net.core.default_qdisc=fq_codel
 net.ipv4.tcp_ecn=1
 net.ipv4.tcp_sack=1
 net.ipv4.tcp_dsack=1
 ```
 
-Note that there is still some broken ECN CPE (e.g. home router)
-equipment out there; if you have problems in some environments, please
-let us know.
+Note that there have been broken routers and networks that are intolerant
+of certain tcp options (or the ordering of those options); we believe these
+problems to have virtually disappeared.  If you have problems in some
+environments, please let us know.
+
+ECN enablement is particularly important on end-hosts.
+If configuring a router/forwarder, check that any custom queueing
+configuration is compatible with fq_codel.
 
 Set the size of the ring buffer for the network interface
 ---------------------------------------------------------

--- a/content/bloat/wiki/Linux_Tips.md
+++ b/content/bloat/wiki/Linux_Tips.md
@@ -115,9 +115,9 @@ of certain tcp options (or the ordering of those options); we believe these
 problems to have virtually disappeared.  If you have problems in some
 environments, please let us know.
 
-ECN enablement is particularly important on end-hosts.
-If configuring a router/forwarder, check that any custom queueing
-configuration is compatible with fq_codel.
+ECN only works if fully enabled on tcp initiator, supported on tcp receiver,
+and the bottleneck router uses an ECN-enabled queue management system such
+as fq_codel.
 
 Set the size of the ring buffer for the network interface
 ---------------------------------------------------------

--- a/content/bloat/wiki/Linux_Tips.md
+++ b/content/bloat/wiki/Linux_Tips.md
@@ -111,11 +111,11 @@ net.ipv4.tcp_dsack=1
 ```
 
 Note that there have been broken routers and networks that are intolerant
-of certain tcp options (or the ordering of those options); we believe these
+of certain TCP options (or the ordering of those options); we believe these
 problems to have virtually disappeared.  If you have problems in some
 environments, please let us know.
 
-ECN only works if fully enabled on tcp initiator, supported on tcp receiver,
+ECN only works if fully enabled on TCP initiator, supported on TCP receiver,
 and the bottleneck router uses an ECN-enabled queue management system such
 as fq_codel.
 


### PR DESCRIPTION
Update Linux Tips for fq_codel and ECN  (ECN being the last part of the puzzle to need widespread enablement).
SACK and DSACK seem to be enabled by default upstream, systemd enables fq_codel by default these days.
Fair comment about TCP option intolerance, I think ECN problem has gone away, e.g. https://www.ietf.org/proceedings/98/slides/slides-98-maprg-tcp-ecn-experience-with-enabling-ecn-on-the-internet-padma-bhooma-00.pdf  and also my own experience!.
Note the "<link>" in markup text didn't seem to work nor to exist as wiki pages, so I removed the tags, consistent with other headings.