### PR TITLE
Update Bloat-videos.md

### DIFF
--- a/content/cerowrt/wiki/Bloat-videos.md
+++ b/content/cerowrt/wiki/Bloat-videos.md
@@ -32,8 +32,8 @@ Van Jacobson (of Google) introduces the codel solution and the packet fountain a
 [Van
 Jacobson](http://www.wired.com/wiredenterprise/2012/05/van-jacobson/)
 speaking about [TCP, Congestion, and CoDel
-cure](https://archive.org/details/video1_20191129
-. The quality of the video is sadly poor, and his slides
+cure](https://archive.org/details/video1_20191129). 
+The quality of the video is sadly poor, and his slides
 ([here](https://www.ietf.org/proceedings/84/slides/slides-84-tsvarea-4.pdf)
 ) not in sync, but follow along, if you can.
 

--- a/content/cerowrt/wiki/Bloat-videos.md
+++ b/content/cerowrt/wiki/Bloat-videos.md
@@ -32,9 +32,9 @@ Van Jacobson (of Google) introduces the codel solution and the packet fountain a
 [Van
 Jacobson](http://www.wired.com/wiredenterprise/2012/05/van-jacobson/)
 speaking about [TCP, Congestion, and CoDel
-cure](http://recordings.conf.meetecho.com/Recordings/watch.jsp?recording=IETF84_TSVAREA&chapter=part_3)
+cure](https://archive.org/details/video1_20191129
 . The quality of the video is sadly poor, and his slides
-([here](https://plus.google.com/u/0/107942175615993706558/posts/eG8wZh7Qshs)
+([here](https://www.ietf.org/proceedings/84/slides/slides-84-tsvarea-4.pdf)
 ) not in sync, but follow along, if you can.
 
 IETF demo side-by-side of a normal cable modem vs fq\_codel


### PR DESCRIPTION
found the Van Jacobson slides on the ietf website, which hopefully will prove more resilient to link-rot long term. I also moved the video link to an archive.org mirror (not an archived page, mind you, but an actual dedicated upload).