### PR TITLE
Remove dslreports.com/speedtest from list of tests

### DIFF
--- a/content/bloat/wiki/TechnicalIntro.md
+++ b/content/bloat/wiki/TechnicalIntro.md
@@ -90,8 +90,9 @@ in many different parts of network systems.
 You see manifestations of bufferbloat today in your operating systems,
 your home network, your broadband connections, possibly your ISP’s and
 corporate networks, at busy conference wireless networks, and on 3G
-networks. You can use the [DSLReports Speed
-Test](http://dslreports.com/speedtest) to measure bufferbloat directly.
+networks. You can use the
+[Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
+to measure bufferbloat directly.
 
 Bufferbloat is a mistake we’ve all made together. What's the solution?
 We have had extremely good results with the

--- a/content/bloat/wiki/Tests_for_Bufferbloat.md
+++ b/content/bloat/wiki/Tests_for_Bufferbloat.md
@@ -25,7 +25,6 @@ read our recommendations at
 ## Easy: Web-based Tests
 
 The web-based tests
-[DSL Reports Speed Test](http://DSLReports.com/speedtest) and
 [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat) and
 [Fast.com](https:/fast.com) (click the "Show more info" button)
 make accurate measurements of the latency *during*

--- a/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
+++ b/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
@@ -16,8 +16,7 @@ It's wasting your time.
 Here's what you can do:
 
 **1. Measure the Bufferbloat:**
-Use the [DSLReports Speed Test](http://dslreports.com/speedtest) or
-[Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
+Use the [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
 to measure the latency under load (this is a good measure of responsiveness).
 If the test shows a letter grade worse than a B, you probably have bufferbloat.
 Most likely, the device at your bottleneck link

--- a/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
+++ b/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
@@ -50,10 +50,9 @@ cake, fq_codel, PIE, or others.
 Here are some options, from easy to harder:
 
 - **Enable SQM settings** if your router already has them.
-First, measure the link speed _without_ SQM 
-(say, using [DSLReports](http://dslreports.com/speedtest) or
-[Waveform](https://www.waveform.com/tools/bufferbloat))
-then turn on SQM and measure again while observing the latency measurements. 
+First, measure the link speed _without_ SQM
+(say, using [Waveform](https://www.waveform.com/tools/bufferbloat))
+then turn on SQM and measure again while observing the latency measurements.
 Start with the no-SQM up and down speed settings keep adjusting and measuring
 until the latency remains low while achieving good speeds.
 See, for example, this description of a [tuning session.](Getting_SQM_Running_Right)

--- a/content/bloat/wiki/index.md
+++ b/content/bloat/wiki/index.md
@@ -13,7 +13,7 @@ Bufferbloat is the undesirable latency that comes from a router or other network
 
 **TL;DR**
 
-1. If you want to measure bufferbloat, go to [DSLReports/speedtest](http://DSLReports.com/speedtest/), or read more at the [Tests for Bufferbloat](./Tests_for_Bufferbloat.md) page.
+1. If you want to measure bufferbloat, go to [Waveform](https://www.waveform.com/tools/bufferbloat), or read more at the [Tests for Bufferbloat](./Tests_for_Bufferbloat.md) page.
 2. To fix your bufferbloat, check out [What Can I Do About Bufferbloat?](./What_can_I_do_about_Bufferbloat/)
 
 The Details

--- a/content/cerowrt/wiki/index.md
+++ b/content/cerowrt/wiki/index.md
@@ -50,7 +50,7 @@ ready for prime time yet.
 Is your internet connection bloated? 
 ------------------------------------
 You can find out right now using
-one of the [Tests for Bufferbloat](/bloat/wiki/Tests_for_Bufferbloat.md) - or just use [DSLReports Speed Test.](http://dslreports.com/speedtest)
+one of the [Tests for Bufferbloat](/bloat/wiki/Tests_for_Bufferbloat.md) - or just use [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat).
 
 If you find bufferbloat is present, read [What Can I do about Bufferbloat.](/bloat/wiki/What_can_I_do_about_Bufferbloat.md)
 

--- a/content/codel/wiki/CakeRecipes.md
+++ b/content/codel/wiki/CakeRecipes.md
@@ -28,9 +28,9 @@ tc qdisc replace dev eth0 root cake docsis ack-filter bandwidth 17mbit
 * _root_ means this is the "top" qdisc.
 * _docsis_ says tune for a cable-tv uplink's overheads: 
 cable TV follows the docsis standards.
-* _ack-filter_ skips sending redundant acknowledgements. 
-* _bandwidth_ is the upload bandwidth of your link, often 
-taken from speed tests like http://www.dslreports.com/speedtest.
+* _ack-filter_ skips sending redundant acknowledgements.
+* _bandwidth_ is the upload bandwidth of your link, often
+taken from speed tests like [Waveform](https://www.waveform.com/tools/bufferbloat).
 
 
 Inbound, General case


### PR DESCRIPTION
Unfortunately, dslreports.com's speed test seems to be non-functional and defunct.

https://www.dslreports.com/forum/r33240157-Speed-Test-Servers-Status