### PR TITLE
Update for IQrouter, change template to "Recent Updates", 

### DIFF
--- a/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
+++ b/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
@@ -1,7 +1,7 @@
 ---
 title: What Can I Do About Bufferbloat?
 date: 2017-03-10T09:10:12
-lastmod: 2022-06-11T08:29:01
+lastmod: 2023-10-20T08:29:01
 type: wiki
 aliases:
     - /bloat/wiki/What_to_do_about_Bufferbloat/
@@ -13,17 +13,29 @@ Bufferbloat is high latency (or lag) that occurs when there's other
 traffic on your network.
 This means that your network isn't responsive under normal working conditions.
 It's wasting your time.
-Here's what you can do:
+
+**How does bufferbloat apply to me?**
+
+Watch the [Bufferbloat Video](https://www.youtube.com/watch?v=UICh3ScfNWI) 
+which presents an intuitive description of of Bufferbloat.
+Or read the somewhat more detailed
+[Best Bufferbloat Analogy - Ever](https://randomneuronsfiring.com/best-bufferbloat-analogy-ever/)
+blog post.
+
+**Most important - How do I get rid of Bufferbloat?**
 
 **1. Measure the Bufferbloat:**
 Use the [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
-to measure the latency under load (this is a good measure of responsiveness).
-If the test shows a letter grade worse than a B, you probably have bufferbloat.
-Most likely, the device at your bottleneck link
+or [Speedtest.net](https://speedtest.net))
+to measure the latency under load.
+If Waveform shows a letter grade worse than a B,
+or if Speedtest.net shows more than 75 msec in either download or upload,
+you probably have bufferbloat.
+Some device at your bottleneck link
 (usually your router) is letting bulk traffic (uploads/downloads) interfere with
 (and delay) your time-sensitive traffic (gaming, video calls, Facetime, etc.)
 For more details about testing,
-read the [Tests for Bufferbloat](./Tests_for_Bufferbloat.md) page.
+read the [Tests for Bufferbloat](./Tests_for_Bufferbloat.md) page. 
 
 **2. Possible Solutions:** There are lots of ways to throw time or money at this problem.
 Most won't work.
@@ -38,31 +50,31 @@ since many commercial, off-the-shelf router manufacturers are clueless about Buf
 
 **3. Take Control of Your Network:**
 No one else (not your router manufacturer,
-nor most ISPs) have as strong an incentive to fix it.
-Once you do, the network will stay fixed for all time, 
+nor your ISP) has a strong incentive to fix Bufferbloat.
+But once you take control, the network will stay fixed for all time, 
 and you can adapt to changing practices at your ISP or other vendors.
 
 You need to find a router vendor that "understands"
 latency/responsiveness/bufferbloat,
-and has updated the firmware to use one of the
-Smart Queue Management algorithms such as
+and has firmware that uses one of the
+Smart Queue Management algorithms such as 
 cake, fq_codel, PIE, or others. 
 Here are some options, from easy to harder:
 
 - **Enable SQM settings** if your router already has them.
 
-First, measure the link speed _without_ SQM
-(say, using [Waveform](https://www.waveform.com/tools/bufferbloat))
-then turn on SQM and measure again while observing the latency measurements.
-Start with the no-SQM up and down speed settings keep adjusting and measuring
+    First, measure the link speed _without_ SQM
+using [Waveform](https://www.waveform.com/tools/bufferbloat)
+or [Speedtest.net](https://speedtest.net).
+Each of these is good because they display latency when the line is idle
+_and_ when there's upload or download traffic.
+Then turn on SQM, setting the up and down speed to the measured values above.
+Keep running your speed test and adjusting the SQM speed settings
 until the latency remains low while achieving good speeds.
 See, for example, this description of a [tuning session.](Getting_SQM_Running_Right)
 
 - **Install an off-the-shelf router with SQM** Several commercial router vendors have a clue. 
     Here is a list of those we have found:
-    * [IQrouter](http://evenroute.com) provides a good setup wizard for
-    configuring SQM, and automatically tunes its settings. 
-    IQrouter v3 is good to about 350 mbps. (Version 2 was good for 200-250 mbps.)
     * [Ubiquiti gear](https://help.ubnt.com/hc/en-us/articles/220716608-EdgeRouter-Advanced-queue-CLI-examples) has fq_codel settings. 
     People say its EdgeRouter will handle over 400 mbps.
     * The [eero mesh routers](https://support.eero.com/hc/en-us/articles/360000709886-What-is-eero-Labs-)
@@ -76,6 +88,9 @@ improved working latency.
 (See Footnote 59 of
 [_Improving Latency with Active Queue Management (AQM) During COVID-19_](https://arxiv.org/ftp/arxiv/papers/2107/2107.13968.pdf)
 for model numbers.)
+    * If you can find one, the [IQrouter](http://evenroute.com) provides a good setup wizard for
+    configuring SQM, and automatically tunes its settings. 
+    IQrouter v3 is good to about 350 mbps. (Version 2 was good for 200-250 mbps.)
     * Many other mesh router vendors claim to solve bufferbloat.
     Check their spec's or ask them about latency.
     * [Untangle NG Firewall](https://wiki.untangle.com/index.php/Bufferbloat) has fq_codel settings.
@@ -86,7 +101,7 @@ have fq\_codel and fq\_PIE settings, courtesy of FreeBSD and
     
 
 -  **Upgrade your current router.**
-Install [OpenWrt firmware](https://OpenWrt.org) (version 22.03, 21.02, 19.07, or 18.06).
+Install [OpenWrt firmware](https://OpenWrt.org) (version 22.03 or newer).
 The [Smart Queue Management guide](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
 tells how to configure the *luci-app-sqm* package.
 Or install suitable [DD-WRT](https://www.dd-wrt.com),

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -6,7 +6,7 @@
             <img src="/images/feed-icon.svg" alt="RSS feed"
             width="20" height="20" style="float: right" />
           </a>
-          <h4>Recent News &amp; Articles</h4>
+          <h4>Recent Updates</h4>
         </div>
         <div class="panel-body">
           {{ range first 5 (where .Site.Pages.ByLastmod.Reverse "Type" "in" .Site.Params.recentTypes)}}


### PR DESCRIPTION
IQrouter no longer seems to be available (not on Amazon or Evenroute.com);
Change to use "Recent Updates" in the template; 
Many editorial tweaks to list Waveform and Speedtest.net equally