### PR TITLE
Add Padavan (TW641's CAKE Port) to custom firmware list

### DIFF
--- a/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
+++ b/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
@@ -124,7 +124,8 @@ In Web GUI follow to **Adaptive QoS → QoS**.
 More customizations via Web GUI is available with [CakeQOS-Merlin](https://github.com/ttgapers/cakeqos-merlin).
     * [DD-WRT](https://www.dd-wrt.com)
     * [Gargoyle](https://www.gargoyle-router.com)
-    * [Tomato](https://freshtomato.org)  
+    * [Tomato](https://freshtomato.org)
+    * [Padavan (TW641's CAKE Port)](https://tw641.github.io/) (142 legacy MediaTek/Ralink models). Brings CAKE to Padavan firmware (Linux 3.4/4.4) while maintaining HWNAT and SFE acceleration.
     * [Raspberry Pi 4](https://www.reddit.com/r/openwrt/comments/l1m801/rpi4_openwrt_tips/) -
       This link provides "some assembly required" instructions
       for installing OpenWrt on a RPi4 and connecting it


### PR DESCRIPTION
Hi team,

I'd like to propose adding the Padavan CAKE backport project to the "Install custom firmware" list.

This project successfully backports the CAKE SQM algorithm to the older Linux kernels (3.4.113 & 4.4.198) used by Padavan. It rescues 142 legacy MediaTek/Ralink models (such as the TP-Link Archer C2, Xiaomi Mi Router 3, etc.) from e-waste, allowing them to mitigate bufferbloat while safely co-existing with vendor Hardware NAT (HWNAT) and SFE acceleration. 

Frank Borsik from LibreQoS has also been very supportive of this effort. Thank you for maintaining this excellent wiki!

Best regards,
Shiyu (TW641)