### PR TITLE
Add Bufferbloat.org to web-based bufferbloat tests

### DIFF
--- a/content/bloat/wiki/Bufferbloat_FAQs.md
+++ b/content/bloat/wiki/Bufferbloat_FAQs.md
@@ -110,6 +110,7 @@ _during_ the download and upload:
 
 * [Speedtest.net](https://www.speedtest.net/)
 * [Waveform Bufferbloat and Internet Speed Test](https://www.waveform.com/tools/bufferbloat)
+* [Bufferbloat.org Internet Reliability Test](https://bufferbloat.org/test)
 * [Cloudflare Speed Test](https://speed.cloudflare.com/)
 
 If the test shows an increase of latency under load

--- a/content/bloat/wiki/TechnicalIntro.md
+++ b/content/bloat/wiki/TechnicalIntro.md
@@ -92,6 +92,8 @@ your home network, your broadband connections, possibly your ISP’s and
 corporate networks, at busy conference wireless networks, and on 3G
 networks. You can use the
 [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
+or the
+[Bufferbloat.org Internet Reliability Test](https://bufferbloat.org/test)
 to measure bufferbloat directly.
 
 Bufferbloat is a mistake we’ve all made together. What's the solution?

--- a/content/bloat/wiki/Tests_for_Bufferbloat.md
+++ b/content/bloat/wiki/Tests_for_Bufferbloat.md
@@ -30,6 +30,8 @@ the download and upload parts of the test.
 
 * [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
 Gives a letter grade for your performance
+* [Bufferbloat.org Internet Reliability Test](https://bufferbloat.org/test)
+Browser-based test of latency during download and upload load, with open-source implementation and published methodology
 * [speedtest.net Test](https://speedtest.net)
 Web, iOS, and Android apps that measure latency
 * [Cloudflare Speed Test](https://speed.cloudflare.com)

--- a/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
+++ b/content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
@@ -29,6 +29,7 @@ Use any of the tests below that measure latency both when
 the line is idle _and_ during upload or download traffic.
 
 * [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat)
+* [Bufferbloat.org Internet Reliability Test](https://bufferbloat.org/test)
 * [Speedtest.net Test](https://speedtest.net)
 * [Cloudflare Speed Test](https://speed.cloudflare.com)
 * [LibreQoS Bufferbloat Test](https://bufferbloat.libreqos.com/)

--- a/content/bloat/wiki/index.md
+++ b/content/bloat/wiki/index.md
@@ -15,6 +15,7 @@ Bufferbloat is the undesirable latency that comes from a router or other network
 
 1. To measure bufferbloat, go to
 [Waveform](https://www.waveform.com/tools/bufferbloat),
+[Bufferbloat.org](https://bufferbloat.org/test),
 [Speedtest.net](https://speedtest.net/), or 
 [Cloudflare](https://speed.cloudflare.com/),
  or read more at the [Tests for Bufferbloat](./Tests_for_Bufferbloat.md) page.

--- a/content/cerowrt/wiki/index.md
+++ b/content/cerowrt/wiki/index.md
@@ -50,7 +50,7 @@ ready for prime time yet.
 Is your internet connection bloated? 
 ------------------------------------
 You can find out right now using
-one of the [Tests for Bufferbloat](/bloat/wiki/Tests_for_Bufferbloat.md) - or just use [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat).
+one of the [Tests for Bufferbloat](/bloat/wiki/Tests_for_Bufferbloat.md) - or just use [Waveform Bufferbloat Test](https://www.waveform.com/tools/bufferbloat) or the [Bufferbloat.org Internet Reliability Test](https://bufferbloat.org/test).
 
 If you find bufferbloat is present, read [What Can I do about Bufferbloat.](/bloat/wiki/What_can_I_do_about_Bufferbloat.md)
 


### PR DESCRIPTION
Thank you for maintaining Bufferbloat.net and the body of documentation around bufferbloat, CoDel, FQ-CoDel, CAKE, and practical testing. I maintain Bufferbloat.org, and I treat this work as foundational: the Bufferbloat.org learning bibliography explicitly describes these sources as "sources I respect and consider foundational to this work", with links to the Bufferbloat Project wiki, Bufferbloat.net, and the CAKE documentation.

This pull request adds Bufferbloat.org's browser-based internet reliability test to existing Bufferbloat.net pages that already point readers to web-based bufferbloat tests. The intent is to add one more test option for readers who are trying to measure latency under load, while keeping the existing page structure and recommendations intact, without implying any official affiliation or endorsement.

The new link is placed immediately after the Waveform test where that ordering exists, and uses the anchor "Bufferbloat.org Internet Reliability Test" where the surrounding page style supports a descriptive label. The main Tests for Bufferbloat page also adds a short description:

Browser-based test of latency during download and upload load, with open-source implementation and published methodology.

The linked test page is:

https://bufferbloat.org/test

The anchor text is lightly adapted from the page title, "Test Internet Reliability: Speed, Latency, and Bufferbloat", to fit the style of the existing lists.

Files changed:

- content/bloat/wiki/Tests_for_Bufferbloat.md
- content/bloat/wiki/What_can_I_do_about_Bufferbloat.md
- content/bloat/wiki/index.md
- content/bloat/wiki/TechnicalIntro.md
- content/bloat/wiki/Bufferbloat_FAQs.md
- content/cerowrt/wiki/index.md

Validation:

- Ran `git diff --check`
- Did not run Hugo preview because this environment does not have `hugo` or `docker` installed; the project README notes Hugo 0.16 is required for local preview.